### PR TITLE
[2024/06/20] feat/#10 exception >> exception 기능 추가

### DIFF
--- a/src/main/java/com/sparta/greeypeople/exception/BadRequestException.java
+++ b/src/main/java/com/sparta/greeypeople/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.sparta.greeypeople.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/greeypeople/exception/ConflictException.java
+++ b/src/main/java/com/sparta/greeypeople/exception/ConflictException.java
@@ -1,0 +1,7 @@
+package com.sparta.greeypeople.exception;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/greeypeople/exception/DataNotFoundException.java
+++ b/src/main/java/com/sparta/greeypeople/exception/DataNotFoundException.java
@@ -1,0 +1,7 @@
+package com.sparta.greeypeople.exception;
+
+public class DataNotFoundException extends RuntimeException {
+    public DataNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/greeypeople/exception/ForbiddenException.java
+++ b/src/main/java/com/sparta/greeypeople/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.sparta.greeypeople.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
@@ -1,6 +1,9 @@
 package com.sparta.greeypeople.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -8,5 +11,16 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 @RestController
 public class GlobalExceptionHandler {
+
+    /**
+     * 클라이언트로 부터 잘못된 요청 값이 들어온 경우
+     * @param ex : BadRequestException[custom]
+     * @return : error message, HttpStatus.BAD_REQUEST => 400
+     */
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<String> badRequestException(BadRequestException ex) {
+        log.error("{}", ex.getMessage());
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
 
 }

--- a/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
@@ -1,0 +1,12 @@
+package com.sparta.greeypeople.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@RestController
+public class GlobalExceptionHandler {
+
+}

--- a/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
@@ -34,5 +34,15 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
     }
 
+    /**
+     * 이미 존재하는 값이 있는 경우
+     * @param ex : ConflictException[custom]
+     * @return : error message, HttpStatus.CONFLICT => 409
+     */
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<String> conflictException(ConflictException ex) {
+        log.error("{}", ex.getMessage());
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
+    }
 
 }

--- a/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
@@ -23,4 +23,16 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
+    /**
+     * DB 조회 시 값이 존재하지 않는 경우
+     * @param ex : DataNotFoundException[custom]
+     * @return : error message, HttpStatus.NOT_FOUND => 404
+     */
+    @ExceptionHandler(DataNotFoundException.class)
+    public ResponseEntity<String> dataNotFoundException(DataNotFoundException ex) {
+        log.error("{}", ex.getMessage());
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+
 }

--- a/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
@@ -90,4 +90,15 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
+    /**
+     * 중복된 좋아요&팔로우가 눌렸을 경우[unique 제약 조건 위배 에러]
+     * @param ex : ViolatedException[custom]
+     * @return : HttpStatus.CONFLICT => 409 : 클라이언트 요청에 대한 서버간 충돌
+     */
+    @ExceptionHandler(ViolatedException.class)
+    public ResponseEntity<String> violatedLikeException(ViolatedException ex) {
+        log.error("{}", ex.getMessage());
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
+    }
+
 }

--- a/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
@@ -3,9 +3,14 @@ package com.sparta.greeypeople.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
@@ -65,6 +70,24 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> forbiddenException(ForbiddenException ex) {
         log.error("{}", ex.getMessage());
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.FORBIDDEN);
+    }
+
+    /**
+     * Valid 유효성 검사 에러 ( 잘못된 요청에 대한 값이 들어온 경우 )
+     * @param ex : MethodArgumentNotValidException
+     * @return : error message, HttpStatus.BAD_REQUEST => 400
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, String>> methodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        log.error("{}", ex.getMessage());
+
+        Map<String, String> errors = new HashMap<>();
+
+        for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
 }

--- a/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
@@ -56,4 +56,15 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.UNAUTHORIZED);
     }
 
+    /**
+     * 인증은 되었으나 접근 권한이 없는 경우
+     * @param ex : ForbiddenException[custom]
+     * @return : error message, HttpStatus.FORBIDDEN => 403
+     */
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<String> forbiddenException(ForbiddenException ex) {
+        log.error("{}", ex.getMessage());
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.FORBIDDEN);
+    }
+
 }

--- a/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/greeypeople/exception/GlobalExceptionHandler.java
@@ -45,4 +45,15 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
     }
 
+    /**
+     * 클라이언트가 유효한 인증 제공을 하지 못한 경우
+     * @param ex : UnauthorizedException[custom]
+     * @return : error message, HttpStatus.UNAUTHORIZED => 401
+     */
+    @ExceptionHandler(UnauthorizedException.class)
+    public ResponseEntity<String> unauthorizedException(UnauthorizedException ex) {
+        log.error("{}", ex.getMessage());
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
 }

--- a/src/main/java/com/sparta/greeypeople/exception/UnauthorizedException.java
+++ b/src/main/java/com/sparta/greeypeople/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.sparta.greeypeople.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/sparta/greeypeople/exception/ViolatedException.java
+++ b/src/main/java/com/sparta/greeypeople/exception/ViolatedException.java
@@ -1,0 +1,7 @@
+package com.sparta.greeypeople.exception;
+
+public class ViolatedException extends RuntimeException {
+    public ViolatedException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #10 
> Close #10 

## 📑 작업 내용

> -  GlobalHandler 추가
> - DataNotFoundException -> 404 ( DB 조회 값 없음 ( null ))
> - BadRequestException -> 400 ( 잘못된 요청 )
> -  ConflictExcepiton -> 409 ( 이미 존재하는 값 )
> -  MethodArgumentNotValidException -> 400 (valid검증)
> - UnauthorizedException -> 401(클라이언트가 유효한 인증 제공X)
> -  ForbiddenException -> 403(인증은 되었으나 접근 권한X)
> -  ViolatedException -> 409(중복된 좋아요&팔로우가 눌렸을 경우 : 클라이언트 요청에 대한 서버간 충돌)

## 💭 리뷰 요구사항(선택)

>
