### PR TITLE
[2024.06.20] feat/#8-like-menu >> 메뉴 좋아요 기능 추가

### DIFF
--- a/src/main/java/com/sparta/greeypeople/like/controller/LikeController.java
+++ b/src/main/java/com/sparta/greeypeople/like/controller/LikeController.java
@@ -1,0 +1,50 @@
+package com.sparta.greeypeople.like.controller;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import com.sparta.greeypeople.common.StatusCommonResponse;
+import com.sparta.greeypeople.exception.BadRequestException;
+import com.sparta.greeypeople.exception.DataNotFoundException;
+import com.sparta.greeypeople.exception.ForbiddenException;
+import com.sparta.greeypeople.exception.ViolatedException;
+import com.sparta.greeypeople.like.service.MenuLikesService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/stores/{storeId}/menus")
+public class LikeController {
+
+	private final MenuLikesService menuLikesService;
+
+	@PostMapping("/{menuId}/like")
+	public ResponseEntity<StatusCommonResponse> addMenuLike(@PathVariable Long menuId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+		try {
+			menuLikesService.addMenuLike(menuId, userDetails.getUser());
+			StatusCommonResponse commonResponse = new StatusCommonResponse(201, "메뉴 좋아요 등록 성공");
+			return ResponseEntity.status(HttpStatus.CREATED).body(commonResponse);
+		} catch (BadRequestException e) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new StatusCommonResponse(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
+		} catch (ViolatedException e) {
+			return ResponseEntity.status(HttpStatus.CONFLICT).body(new StatusCommonResponse(HttpStatus.CONFLICT.value(), e.getMessage()));
+		}
+	}
+
+	@DeleteMapping("/{menuLikeId}/like")
+	public ResponseEntity<StatusCommonResponse> removeMenuLike(@PathVariable Long menuLikeId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+		try {
+			menuLikesService.removeMenuLike(menuLikeId, userDetails.getUser());
+			StatusCommonResponse commonResponse = new StatusCommonResponse(204, "메뉴 좋아요 삭제 성공");
+			return ResponseEntity.status(HttpStatus.NO_CONTENT).body(commonResponse);
+		} catch (DataNotFoundException e) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new StatusCommonResponse(HttpStatus.NOT_FOUND.value(), e.getMessage()));
+		} catch (ForbiddenException e) {
+			return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new StatusCommonResponse(HttpStatus.FORBIDDEN.value(), e.getMessage()));
+		}
+	}
+
+}

--- a/src/main/java/com/sparta/greeypeople/like/entity/MenuLikes.java
+++ b/src/main/java/com/sparta/greeypeople/like/entity/MenuLikes.java
@@ -1,0 +1,33 @@
+package com.sparta.greeypeople.like.entity;
+
+import com.sparta.greeypeople.menu.entity.Menu;
+import com.sparta.greeypeople.timestamp.TimeStamp;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "menuLikes_table")
+@NoArgsConstructor
+public class MenuLikes extends TimeStamp {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "menu_id", nullable = false)
+	private Menu menu;
+
+	@Builder
+	public MenuLikes(User user, Menu menu) {
+		this.user = user;
+		this.menu = menu;
+	}
+}

--- a/src/main/java/com/sparta/greeypeople/like/repository/MenuLikesRepository.java
+++ b/src/main/java/com/sparta/greeypeople/like/repository/MenuLikesRepository.java
@@ -1,0 +1,14 @@
+package com.sparta.greeypeople.like.repository;
+
+import com.sparta.greeypeople.menu.entity.Menu;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.sparta.greeypeople.like.entity.MenuLikes;
+
+@Repository
+public interface MenuLikesRepository extends JpaRepository<MenuLikes, Long> {
+	Optional<MenuLikes> findByUserAndMenu(User foundUser, Menu foundMenu);
+}

--- a/src/main/java/com/sparta/greeypeople/like/service/MenuLikesService.java
+++ b/src/main/java/com/sparta/greeypeople/like/service/MenuLikesService.java
@@ -1,0 +1,63 @@
+package com.sparta.greeypeople.like.service;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.sparta.greeypeople.exception.BadRequestException;
+import com.sparta.greeypeople.exception.DataNotFoundException;
+import com.sparta.greeypeople.exception.ForbiddenException;
+import com.sparta.greeypeople.exception.ViolatedException;
+import com.sparta.greeypeople.like.entity.MenuLikes;
+import com.sparta.greeypeople.like.repository.MenuLikesRepository;
+import com.sparta.greeypeople.menu.entity.Menu;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MenuLikesService {
+
+	private final MenuLikesRepository menuLikesRepository;
+	private final UserService userService;
+	private final MenuService menuService;
+
+	@Transactional
+	public void addMenuLike(Long menuId, User user) {
+
+		User foundUser = userService.findById(user.getId());
+		Menu foundMenu = menuService.findById(menuId);
+
+		if (foundUser.getUserId().equals(foundMenu.getUser().getUserId())) {
+			throw new BadRequestException("자신이 등록한 메뉴에는 좋아요를 남길 수 없습니다.");
+		}
+
+		var MenuLikes = new MenuLikes(foundUser, foundMenu);
+
+		if (menuLikesRepository.findByUserAndMenu(foundUser, foundMenu).isPresent()) {
+			throw new ViolatedException("이미 좋아요를 누른 메뉴입니다.");
+		}
+
+		menuLikesRepository.save(MenuLikes);
+		foundMenu.addLike();
+	}
+
+	@Transactional
+	public void removeMenuLike(Long menuLikeId, User user) {
+
+		MenuLikes foundlike = menuLikesRepository.findById(menuLikeId).orElseThrow(
+			() -> new DataNotFoundException("해당 좋아요가 존재하지 않습니다."));
+
+		Menu foundMenu = menuService.findById(foundlike.getMenu().getId());
+
+		if (!(user.getUserId().equals(foundlike.getUser().getUserId()))) {
+			throw new ForbiddenException("다른 사람의 좋아요는 삭제할 수 없습니다.");
+		}
+
+		menuLikesRepository.delete(foundlike);
+		foundMenu.minusLike();
+	}
+
+}

--- a/src/main/java/com/sparta/greeypeople/menu/entity/Menu.java
+++ b/src/main/java/com/sparta/greeypeople/menu/entity/Menu.java
@@ -22,4 +22,15 @@ public class Menu {
 //    @ManyToOne(fetch = FetchType.LAZY)
 //    @JoinColumn(name = "store_id", nullable = false)
 //    private Store store;
+
+    @Column
+    private Long menuLikes;
+
+    public void addLike() {
+        this.menuLikes = menuLikes + 1L;
+    }
+
+    public void minusLike() {
+        this.menuLikes = menuLikes - 1L;
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #8 
> Close #8

## 📑 작업 내용

> - 메뉴에 대한 좋아요 등록과 취소 기능 구현
> - 본인이 등록한 메뉴에는 좋아요 등록 시도 시와 이미 좋아요를 누른 메뉴에 등록 시도 시에 대한 예외 처리
> - 존재하지 않는 좋아요를 취소하려 하거나 다른 사람의 좋아요를 취소하려고 할 시에 대한 예외 처리

## 💭 리뷰 요구사항(선택)

> 메뉴에 대한 좋아요와 리뷰에 대한 좋아요를 하나의 LikeController에서 관리하려 하는데 의견 남겨주시면 감사하겠습니다. (각각 좋아요 등록,취소 2개씩 있어서)

> 예외처리 시 정의해놓은 예외처리를 상황에 맞게 올바르게 잘 사용한 것이 맞는지 확인 부탁드립니다.

> 코드 상 User를 사용하는데 현재 최신 코드에는 User가 아직 추가되어 있지 않아 코드 수정 예정인 점을 양해하고 봐주세요.
